### PR TITLE
fix: LAN IP detection fails when VPN is active (Android 12+)

### DIFF
--- a/app/src/main/java/com/psiphon3/HomeTabFragment.java
+++ b/app/src/main/java/com/psiphon3/HomeTabFragment.java
@@ -257,86 +257,157 @@ public class HomeTabFragment extends Fragment {
 
     /**
      * Get the device's LAN IPv4 address using a multi-strategy approach.
-     * Strategy 1: ConnectivityManager + LinkProperties (API 23+, most reliable)
-     * Strategy 2: NetworkInterface enumeration (all API levels)
-     * Strategy 3: WifiManager (pre-API 31 fallback)
+     * This must work reliably even when our own VPN is active — the VPN
+     * obscures the real Wi-Fi/Ethernet IP in several Android APIs.
+     *
+     * Strategy 1 (API 23+): ConnectivityManager — iterate ALL networks
+     *   looking for TRANSPORT_WIFI or TRANSPORT_ETHERNET (skip VPN/cellular),
+     *   then read LinkProperties for a site-local IPv4 address.
+     *
+     * Strategy 2 (all levels): NetworkInterface enumeration — walk every
+     *   interface, skip known non-LAN names (tun, ppp, rmnet, lo, dummy,
+     *   p2p, wigig), and return the first site-local IPv4 address.
+     *
+     * Strategy 3 (all levels, deprecated but functional through API 34+):
+     *   WifiManager.getConnectionInfo().getIpAddress() — returns the raw
+     *   Wi-Fi IPv4 even with VPN active because it reads from the Wi-Fi
+     *   HAL directly, not from the routing table.
+     *
+     * Every strategy is tried in order; the first non-null result wins.
      */
     private static String getLanIpAddress(Context context) {
+        // Strategy 1: ConnectivityManager + LinkProperties (most authoritative)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             String ip = getLanIpFromConnectivityManager(context);
             if (ip != null) return ip;
         }
 
+        // Strategy 2: NetworkInterface enumeration
         String ip = getLanIpFromNetworkInterfaces();
         if (ip != null) return ip;
 
-        if (Build.VERSION.SDK_INT < 31) {
-            return getLanIpFromWifiManager(context);
-        }
-        return null;
+        // Strategy 3: WifiManager — deprecated but still functional on all
+        // API levels through at least API 34. This is our most reliable
+        // fallback because it reads the Wi-Fi IP directly from the HAL,
+        // bypassing any VPN routing interference.
+        return getLanIpFromWifiManager(context);
     }
 
+    /**
+     * Strategy 1: Walk all networks via ConnectivityManager looking for a
+     * Wi-Fi or Ethernet transport that is NOT a VPN. When our VPN is active,
+     * getActiveNetwork() returns the VPN network, so we must iterate
+     * getAllNetworks() to find the underlying physical network.
+     */
     @android.annotation.TargetApi(Build.VERSION_CODES.M)
     private static String getLanIpFromConnectivityManager(Context context) {
         ConnectivityManager cm = (ConnectivityManager)
                 context.getSystemService(Context.CONNECTIVITY_SERVICE);
         if (cm == null) return null;
 
-        // When a VPN is active, getActiveNetwork() returns the VPN network,
-        // not the underlying Wi-Fi. Iterate all networks to find Wi-Fi.
-        for (Network network : cm.getAllNetworks()) {
-            NetworkCapabilities capabilities = cm.getNetworkCapabilities(network);
-            if (capabilities == null ||
-                    !capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
-                continue;
-            }
-            LinkProperties linkProperties = cm.getLinkProperties(network);
-            if (linkProperties == null) continue;
-            for (android.net.LinkAddress linkAddress : linkProperties.getLinkAddresses()) {
-                InetAddress address = linkAddress.getAddress();
-                if (address instanceof Inet4Address && !address.isLoopbackAddress()) {
-                    return address.getHostAddress();
+        try {
+            for (Network network : cm.getAllNetworks()) {
+                NetworkCapabilities capabilities = cm.getNetworkCapabilities(network);
+                if (capabilities == null) continue;
+
+                // Skip VPN and cellular transports — we only want the
+                // physical LAN network (Wi-Fi or Ethernet).
+                if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) continue;
+                if (!capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) &&
+                        !capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+                    continue;
+                }
+
+                LinkProperties linkProperties = cm.getLinkProperties(network);
+                if (linkProperties == null) continue;
+                for (android.net.LinkAddress linkAddress : linkProperties.getLinkAddresses()) {
+                    InetAddress address = linkAddress.getAddress();
+                    if (address instanceof Inet4Address &&
+                            !address.isLoopbackAddress() &&
+                            address.isSiteLocalAddress()) {
+                        return address.getHostAddress();
+                    }
                 }
             }
+        } catch (Exception ignored) {
+            // SecurityException possible on some OEMs; fall through to next strategy
         }
         return null;
     }
 
+    /**
+     * Strategy 2: Enumerate all NetworkInterfaces and return the first
+     * site-local IPv4 address on a physical-looking interface. We skip
+     * known virtual/tunnel interface name prefixes.
+     */
     private static String getLanIpFromNetworkInterfaces() {
         try {
             Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
             if (interfaces == null) return null;
+
+            // Collect candidates — prefer wlan/eth over others
+            String otherCandidate = null;
+
             for (NetworkInterface ni : Collections.list(interfaces)) {
                 if (ni.isLoopback() || !ni.isUp()) continue;
                 String name = ni.getName().toLowerCase();
+
+                // Skip known non-LAN interfaces
                 if (name.startsWith("tun") || name.startsWith("ppp") ||
                         name.startsWith("rmnet") || name.startsWith("lo") ||
-                        name.startsWith("dummy")) {
+                        name.startsWith("dummy") || name.startsWith("p2p") ||
+                        name.startsWith("wigig") || name.startsWith("v4-") ||
+                        name.startsWith("clat")) {
                     continue;
                 }
+
                 for (InetAddress addr : Collections.list(ni.getInetAddresses())) {
-                    if (addr instanceof Inet4Address && !addr.isLoopbackAddress()
-                            && addr.isSiteLocalAddress()) {
-                        return addr.getHostAddress();
+                    if (addr instanceof Inet4Address &&
+                            !addr.isLoopbackAddress() &&
+                            addr.isSiteLocalAddress()) {
+                        String ip = addr.getHostAddress();
+                        if (name.startsWith("wlan") || name.startsWith("eth") ||
+                                name.startsWith("en")) {
+                            // High-confidence LAN interface — return immediately
+                            return ip;
+                        }
+                        if (otherCandidate == null) {
+                            otherCandidate = ip;
+                        }
                     }
                 }
             }
+
+            // Return best candidate found
+            return otherCandidate;
         } catch (SocketException ignored) {}
         return null;
     }
 
+    /**
+     * Strategy 3: WifiManager.getConnectionInfo().getIpAddress() reads the
+     * IPv4 address directly from the Wi-Fi HAL, so it works correctly even
+     * when a VPN is the active network. The API is deprecated since API 31
+     * but remains functional and returns correct values through at least
+     * Android 14 (API 34). This is the most reliable single-call fallback.
+     */
     @SuppressWarnings("deprecation")
     private static String getLanIpFromWifiManager(Context context) {
-        WifiManager wm = (WifiManager)
-                context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-        if (wm == null) return null;
-        WifiInfo info = wm.getConnectionInfo();
-        if (info == null) return null;
-        int ipInt = info.getIpAddress();
-        if (ipInt == 0) return null;
-        return String.format("%d.%d.%d.%d",
-                (ipInt & 0xff), (ipInt >> 8 & 0xff),
-                (ipInt >> 16 & 0xff), (ipInt >> 24 & 0xff));
+        try {
+            WifiManager wm = (WifiManager)
+                    context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+            if (wm == null) return null;
+            WifiInfo info = wm.getConnectionInfo();
+            if (info == null) return null;
+            int ipInt = info.getIpAddress();
+            if (ipInt == 0) return null;
+            return String.format("%d.%d.%d.%d",
+                    (ipInt & 0xff), (ipInt >> 8 & 0xff),
+                    (ipInt >> 16 & 0xff), (ipInt >> 24 & 0xff));
+        } catch (Exception ignored) {
+            // SecurityException on some OEMs without ACCESS_WIFI_STATE
+            return null;
+        }
     }
 
     private void startPulseAnimation() {


### PR DESCRIPTION
Proxy addresses weren't showing on the home screen on Android 12+ because our IP detection couldn't find the Wi-Fi address through the VPN.

The main problem was simple: Strategy 3 (WifiManager) — which reads the IP straight from the Wi-Fi hardware and isn't affected by VPN routing at all — was gated behind `SDK_INT < 31` and never ran on Android 12+. Removed that gate. It's deprecated but still works fine through at least Android 14.

While I was in there, hardened the other two strategies too:

- Strategy 1 (ConnectivityManager): now explicitly skips VPN networks, also accepts Ethernet, validates isSiteLocalAddress(), and catches OEM SecurityExceptions

- Strategy 2 (NetworkInterface): expanded the virtual interface blocklist (added p2p, wigig, v4-, clat), and prefers known LAN interfaces like wlan/eth over random matches