### PR TITLE
Show available proxy addresses for network sharing

### DIFF
--- a/app/src/main/java/com/psiphon3/HomeTabFragment.java
+++ b/app/src/main/java/com/psiphon3/HomeTabFragment.java
@@ -22,12 +22,6 @@ package com.psiphon3;
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator;
 import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.LinkProperties;
-import android.net.Network;
-import android.net.NetworkCapabilities;
-import android.net.wifi.WifiInfo;
-import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -52,14 +46,9 @@ import androidx.lifecycle.ViewModelProvider;
 
 import com.psiphon3.psiphonlibrary.EmbeddedValues;
 import com.psiphon3.psiphonlibrary.LocalizedActivities;
+import com.psiphon3.psiphonlibrary.LocalProxyInterfaces;
 
-import java.net.Inet4Address;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
+import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -83,6 +72,7 @@ public class HomeTabFragment extends Fragment {
     private LinearLayout lanProxyInfoSection;
     private TextView lanProxyHttpText;
     private TextView lanProxySocksText;
+    private TextView lanProxyInterfacesText;
 
     @Nullable
     @Override
@@ -114,6 +104,7 @@ public class HomeTabFragment extends Fragment {
         lanProxyInfoSection = view.findViewById(R.id.lanProxyInfoSection);
         lanProxyHttpText = view.findViewById(R.id.lanProxyHttpText);
         lanProxySocksText = view.findViewById(R.id.lanProxySocksText);
+        lanProxyInterfacesText = view.findViewById(R.id.lanProxyInterfacesText);
 
         viewModel = new ViewModelProvider(requireActivity(),
                 new ViewModelProvider.AndroidViewModelFactory(requireActivity().getApplication()))
@@ -218,12 +209,6 @@ public class HomeTabFragment extends Fragment {
             return;
         }
 
-        String lanIp = getLanIpAddress(context);
-        if (lanIp == null) {
-            hideLanProxyInfo();
-            return;
-        }
-
         int httpPort = connectionData.httpPort();
         int socksPort = connectionData.socksPort();
 
@@ -232,6 +217,14 @@ public class HomeTabFragment extends Fragment {
             return;
         }
 
+        List<LocalProxyInterfaces.InterfaceAddress> addresses =
+                LocalProxyInterfaces.getAvailableAddresses();
+        if (addresses.isEmpty()) {
+            hideLanProxyInfo();
+            return;
+        }
+
+        String lanIp = addresses.get(0).address();
         lanProxyInfoSection.setVisibility(View.VISIBLE);
 
         if (httpPort > 0) {
@@ -247,166 +240,15 @@ public class HomeTabFragment extends Fragment {
         } else {
             lanProxySocksText.setVisibility(View.GONE);
         }
+
+        lanProxyInterfacesText.setText(LocalProxyInterfaces.formatProxyAddresses(
+                context, addresses, httpPort, socksPort));
+        lanProxyInterfacesText.setVisibility(View.VISIBLE);
     }
 
     private void hideLanProxyInfo() {
         if (lanProxyInfoSection != null) {
             lanProxyInfoSection.setVisibility(View.GONE);
-        }
-    }
-
-    /**
-     * Get the device's LAN IPv4 address using a multi-strategy approach.
-     * This must work reliably even when our own VPN is active — the VPN
-     * obscures the real Wi-Fi/Ethernet IP in several Android APIs.
-     *
-     * Strategy 1 (API 23+): ConnectivityManager — iterate ALL networks
-     *   looking for TRANSPORT_WIFI or TRANSPORT_ETHERNET (skip VPN/cellular),
-     *   then read LinkProperties for a site-local IPv4 address.
-     *
-     * Strategy 2 (all levels): NetworkInterface enumeration — walk every
-     *   interface, skip known non-LAN names (tun, ppp, rmnet, lo, dummy,
-     *   p2p, wigig), and return the first site-local IPv4 address.
-     *
-     * Strategy 3 (all levels, deprecated but functional through API 34+):
-     *   WifiManager.getConnectionInfo().getIpAddress() — returns the raw
-     *   Wi-Fi IPv4 even with VPN active because it reads from the Wi-Fi
-     *   HAL directly, not from the routing table.
-     *
-     * Every strategy is tried in order; the first non-null result wins.
-     */
-    private static String getLanIpAddress(Context context) {
-        // Strategy 1: ConnectivityManager + LinkProperties (most authoritative)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            String ip = getLanIpFromConnectivityManager(context);
-            if (ip != null) return ip;
-        }
-
-        // Strategy 2: NetworkInterface enumeration
-        String ip = getLanIpFromNetworkInterfaces();
-        if (ip != null) return ip;
-
-        // Strategy 3: WifiManager — deprecated but still functional on all
-        // API levels through at least API 34. This is our most reliable
-        // fallback because it reads the Wi-Fi IP directly from the HAL,
-        // bypassing any VPN routing interference.
-        return getLanIpFromWifiManager(context);
-    }
-
-    /**
-     * Strategy 1: Walk all networks via ConnectivityManager looking for a
-     * Wi-Fi or Ethernet transport that is NOT a VPN. When our VPN is active,
-     * getActiveNetwork() returns the VPN network, so we must iterate
-     * getAllNetworks() to find the underlying physical network.
-     */
-    @android.annotation.TargetApi(Build.VERSION_CODES.M)
-    private static String getLanIpFromConnectivityManager(Context context) {
-        ConnectivityManager cm = (ConnectivityManager)
-                context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        if (cm == null) return null;
-
-        try {
-            for (Network network : cm.getAllNetworks()) {
-                NetworkCapabilities capabilities = cm.getNetworkCapabilities(network);
-                if (capabilities == null) continue;
-
-                // Skip VPN and cellular transports — we only want the
-                // physical LAN network (Wi-Fi or Ethernet).
-                if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) continue;
-                if (!capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) &&
-                        !capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
-                    continue;
-                }
-
-                LinkProperties linkProperties = cm.getLinkProperties(network);
-                if (linkProperties == null) continue;
-                for (android.net.LinkAddress linkAddress : linkProperties.getLinkAddresses()) {
-                    InetAddress address = linkAddress.getAddress();
-                    if (address instanceof Inet4Address &&
-                            !address.isLoopbackAddress() &&
-                            address.isSiteLocalAddress()) {
-                        return address.getHostAddress();
-                    }
-                }
-            }
-        } catch (Exception ignored) {
-            // SecurityException possible on some OEMs; fall through to next strategy
-        }
-        return null;
-    }
-
-    /**
-     * Strategy 2: Enumerate all NetworkInterfaces and return the first
-     * site-local IPv4 address on a physical-looking interface. We skip
-     * known virtual/tunnel interface name prefixes.
-     */
-    private static String getLanIpFromNetworkInterfaces() {
-        try {
-            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-            if (interfaces == null) return null;
-
-            // Collect candidates — prefer wlan/eth over others
-            String otherCandidate = null;
-
-            for (NetworkInterface ni : Collections.list(interfaces)) {
-                if (ni.isLoopback() || !ni.isUp()) continue;
-                String name = ni.getName().toLowerCase();
-
-                // Skip known non-LAN interfaces
-                if (name.startsWith("tun") || name.startsWith("ppp") ||
-                        name.startsWith("rmnet") || name.startsWith("lo") ||
-                        name.startsWith("dummy") || name.startsWith("p2p") ||
-                        name.startsWith("wigig") || name.startsWith("v4-") ||
-                        name.startsWith("clat")) {
-                    continue;
-                }
-
-                for (InetAddress addr : Collections.list(ni.getInetAddresses())) {
-                    if (addr instanceof Inet4Address &&
-                            !addr.isLoopbackAddress() &&
-                            addr.isSiteLocalAddress()) {
-                        String ip = addr.getHostAddress();
-                        if (name.startsWith("wlan") || name.startsWith("eth") ||
-                                name.startsWith("en")) {
-                            // High-confidence LAN interface — return immediately
-                            return ip;
-                        }
-                        if (otherCandidate == null) {
-                            otherCandidate = ip;
-                        }
-                    }
-                }
-            }
-
-            // Return best candidate found
-            return otherCandidate;
-        } catch (SocketException ignored) {}
-        return null;
-    }
-
-    /**
-     * Strategy 3: WifiManager.getConnectionInfo().getIpAddress() reads the
-     * IPv4 address directly from the Wi-Fi HAL, so it works correctly even
-     * when a VPN is the active network. The API is deprecated since API 31
-     * but remains functional and returns correct values through at least
-     * Android 14 (API 34). This is the most reliable single-call fallback.
-     */
-    @SuppressWarnings("deprecation")
-    private static String getLanIpFromWifiManager(Context context) {
-        try {
-            WifiManager wm = (WifiManager)
-                    context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-            if (wm == null) return null;
-            WifiInfo info = wm.getConnectionInfo();
-            if (info == null) return null;
-            int ipInt = info.getIpAddress();
-            if (ipInt == 0) return null;
-            return String.format("%d.%d.%d.%d",
-                    (ipInt & 0xff), (ipInt >> 8 & 0xff),
-                    (ipInt >> 16 & 0xff), (ipInt >> 24 & 0xff));
-        } catch (Exception ignored) {
-            // SecurityException on some OEMs without ACCESS_WIFI_STATE
-            return null;
         }
     }
 

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/LocalProxyInterfaces.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/LocalProxyInterfaces.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2022, Psiphon Inc.
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.psiphon3.psiphonlibrary;
+
+import android.content.Context;
+
+import com.psiphon3.R;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+public final class LocalProxyInterfaces {
+    private LocalProxyInterfaces() {}
+
+    public static final class InterfaceAddress {
+        private final String interfaceName;
+        private final String address;
+        private final int typeStringId;
+        private final int rank;
+
+        private InterfaceAddress(String interfaceName, String address, int typeStringId, int rank) {
+            this.interfaceName = interfaceName;
+            this.address = address;
+            this.typeStringId = typeStringId;
+            this.rank = rank;
+        }
+
+        public String interfaceName() {
+            return interfaceName;
+        }
+
+        public String address() {
+            return address;
+        }
+
+        public String displayName(Context context) {
+            return context.getString(R.string.lan_proxy_interface_name,
+                    context.getString(typeStringId), interfaceName);
+        }
+    }
+
+    public static List<InterfaceAddress> getAvailableAddresses() {
+        ArrayList<InterfaceAddress> addresses = new ArrayList<>();
+        Set<String> seenAddresses = new HashSet<>();
+
+        try {
+            java.util.Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            if (interfaces == null) {
+                return addresses;
+            }
+
+            for (NetworkInterface networkInterface : Collections.list(interfaces)) {
+                if (!isUsableInterface(networkInterface)) {
+                    continue;
+                }
+
+                String interfaceName = networkInterface.getName();
+                InterfaceType interfaceType = classify(interfaceName);
+
+                for (InetAddress inetAddress : Collections.list(networkInterface.getInetAddresses())) {
+                    if (!(inetAddress instanceof Inet4Address) ||
+                            inetAddress.isLoopbackAddress() ||
+                            !inetAddress.isSiteLocalAddress()) {
+                        continue;
+                    }
+
+                    String hostAddress = inetAddress.getHostAddress();
+                    if (hostAddress == null || !seenAddresses.add(hostAddress)) {
+                        continue;
+                    }
+
+                    addresses.add(new InterfaceAddress(interfaceName, hostAddress,
+                            interfaceType.stringId, interfaceType.rank));
+                }
+            }
+        } catch (SocketException ignored) {
+        }
+
+        Collections.sort(addresses, new Comparator<InterfaceAddress>() {
+            @Override
+            public int compare(InterfaceAddress left, InterfaceAddress right) {
+                if (left.rank != right.rank) {
+                    return left.rank - right.rank;
+                }
+                return left.interfaceName.compareTo(right.interfaceName);
+            }
+        });
+
+        return addresses;
+    }
+
+    public static String formatProxyAddresses(Context context, List<InterfaceAddress> addresses,
+                                              int httpPort, int socksPort) {
+        StringBuilder builder = new StringBuilder();
+        for (InterfaceAddress address : addresses) {
+            if (builder.length() > 0) {
+                builder.append("\n\n");
+            }
+
+            builder.append(address.displayName(context));
+
+            if (httpPort > 0) {
+                builder.append('\n')
+                        .append(context.getString(R.string.lan_proxy_http_address,
+                                address.address(), httpPort));
+            }
+            if (socksPort > 0) {
+                builder.append('\n')
+                        .append(context.getString(R.string.lan_proxy_socks_address,
+                                address.address(), socksPort));
+            }
+        }
+        return builder.toString();
+    }
+
+    public static String formatInterfaceAddresses(Context context, List<InterfaceAddress> addresses) {
+        StringBuilder builder = new StringBuilder();
+        for (InterfaceAddress address : addresses) {
+            if (builder.length() > 0) {
+                builder.append("\n");
+            }
+            builder.append(context.getString(R.string.lan_proxy_interface_address,
+                    address.displayName(context), address.address()));
+        }
+        return builder.toString();
+    }
+
+    private static boolean isUsableInterface(NetworkInterface networkInterface) throws SocketException {
+        if (!networkInterface.isUp() || networkInterface.isLoopback()) {
+            return false;
+        }
+
+        String name = networkInterface.getName();
+        if (name == null) {
+            return false;
+        }
+
+        String lowerName = name.toLowerCase(Locale.US);
+        return !(lowerName.startsWith("tun") ||
+                lowerName.startsWith("ppp") ||
+                lowerName.startsWith("ipsec") ||
+                lowerName.startsWith("wg") ||
+                lowerName.startsWith("rmnet") ||
+                lowerName.startsWith("ccmni") ||
+                lowerName.startsWith("ccemni") ||
+                lowerName.startsWith("rev_rmnet") ||
+                lowerName.startsWith("lo") ||
+                lowerName.startsWith("dummy") ||
+                lowerName.startsWith("p2p") ||
+                lowerName.startsWith("wigig") ||
+                lowerName.startsWith("v4-") ||
+                lowerName.startsWith("clat") ||
+                lowerName.startsWith("sit") ||
+                lowerName.startsWith("ip6tnl"));
+    }
+
+    private static InterfaceType classify(String interfaceName) {
+        String name = interfaceName.toLowerCase(Locale.US);
+
+        if (name.startsWith("ap") || name.startsWith("swlan")) {
+            return new InterfaceType(R.string.lan_proxy_interface_hotspot, 0);
+        }
+        if (name.startsWith("wlan") || name.startsWith("wifi")) {
+            return new InterfaceType(R.string.lan_proxy_interface_wifi, 1);
+        }
+        if (name.startsWith("rndis") || name.startsWith("usb")) {
+            return new InterfaceType(R.string.lan_proxy_interface_usb, 2);
+        }
+        if (name.startsWith("eth") || name.startsWith("en")) {
+            return new InterfaceType(R.string.lan_proxy_interface_ethernet, 3);
+        }
+        if (name.startsWith("bt-pan") || name.startsWith("bnep")) {
+            return new InterfaceType(R.string.lan_proxy_interface_bluetooth, 4);
+        }
+        return new InterfaceType(R.string.lan_proxy_interface_local, 5);
+    }
+
+    private static final class InterfaceType {
+        final int stringId;
+        final int rank;
+
+        InterfaceType(int stringId, int rank) {
+            this.stringId = stringId;
+            this.rank = rank;
+        }
+    }
+}

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/MoreOptionsPreferenceActivity.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/MoreOptionsPreferenceActivity.java
@@ -44,6 +44,8 @@ import androidx.preference.SwitchPreference;
 import com.psiphon3.MainActivityViewModel;
 import com.psiphon3.R;
 
+import net.grandcentrix.tray.AppPreferences;
+
 public class MoreOptionsPreferenceActivity extends LocalizedActivities.AppCompatActivity {
     public static final String INTENT_EXTRA_LANGUAGE_CHANGED = "com.psiphon3.psiphonlibrary.MoreOptionsPreferenceActivity.LANGUAGE_CHANGED";
 
@@ -67,6 +69,7 @@ public class MoreOptionsPreferenceActivity extends LocalizedActivities.AppCompat
         ListPreference mLanguageSelector;
         EditTextPreference mCdnFrontingCustomIpList;
         EditTextPreference mCdnFrontingCustomSni;
+        Preference mNetworkSharingAddresses;
 
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             super.onCreatePreferences(savedInstanceState, rootKey);
@@ -172,6 +175,14 @@ public class MoreOptionsPreferenceActivity extends LocalizedActivities.AppCompat
                 });
             }
 
+            Preference cdnFrontingScanner = preferences.findPreference("cdnFrontingScanner");
+            if (cdnFrontingScanner != null) {
+                cdnFrontingScanner.setOnPreferenceClickListener(preference -> {
+                    startActivity(new Intent(getActivity(), CdnFrontingScannerActivity.class));
+                    return true;
+                });
+            }
+
             // Beast mode (aggressive establishment)
             SwitchPreference beastModeSwitch =
                     (SwitchPreference) preferences.findPreference(getString(R.string.beastModePreference));
@@ -216,6 +227,13 @@ public class MoreOptionsPreferenceActivity extends LocalizedActivities.AppCompat
         @Override
         public void onResume() {
             super.onResume();
+            if (mCdnFrontingCustomIpList != null) {
+                String customIpList = getPreferenceGetter().getString(
+                        getString(R.string.cdnFrontingCustomIpListPreference), "");
+                mCdnFrontingCustomIpList.setText(customIpList);
+                updateCdnFrontingCustomIpSummary(mCdnFrontingCustomIpList, customIpList);
+            }
+            updateNetworkSharingAddressesSummary();
             // Set up a listener whenever a key changes
             getPreferenceScreen().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
         }
@@ -540,6 +558,9 @@ public class MoreOptionsPreferenceActivity extends LocalizedActivities.AppCompat
         }
 
         private void setupNetworkSharing(PreferenceScreen preferences, PreferenceGetter preferenceGetter) {
+            mNetworkSharingAddresses = preferences.findPreference("networkSharingAddresses");
+            updateNetworkSharingAddressesSummary();
+
             SwitchPreference shareProxySwitch =
                     (SwitchPreference) preferences.findPreference(getString(R.string.shareProxyOnNetworkPreference));
             if (shareProxySwitch != null) {
@@ -571,6 +592,34 @@ public class MoreOptionsPreferenceActivity extends LocalizedActivities.AppCompat
                         return true;
                     }
                 });
+            }
+        }
+
+        private void updateNetworkSharingAddressesSummary() {
+            if (mNetworkSharingAddresses == null) {
+                return;
+            }
+
+            java.util.List<LocalProxyInterfaces.InterfaceAddress> addresses =
+                    LocalProxyInterfaces.getAvailableAddresses();
+            if (addresses.isEmpty()) {
+                mNetworkSharingAddresses.setSummary(
+                        getString(R.string.preference_network_sharing_addresses_unavailable));
+                return;
+            }
+
+            AppPreferences preferences = new AppPreferences(requireContext());
+            int httpPort = preferences.getInt(getString(R.string.current_local_http_proxy_port), 0);
+            int socksPort = preferences.getInt(getString(R.string.current_local_socks_proxy_port), 0);
+
+            if (httpPort > 0 || socksPort > 0) {
+                mNetworkSharingAddresses.setSummary(LocalProxyInterfaces.formatProxyAddresses(
+                        requireContext(), addresses, httpPort, socksPort));
+            } else {
+                mNetworkSharingAddresses.setSummary(
+                        LocalProxyInterfaces.formatInterfaceAddresses(requireContext(), addresses) +
+                                "\n\n" +
+                                getString(R.string.preference_network_sharing_addresses_ports_unavailable));
             }
         }
 

--- a/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
+++ b/app/src/main/java/com/psiphon3/psiphonlibrary/TunnelManager.java
@@ -993,6 +993,28 @@ public class TunnelManager implements PsiphonTunnel.HostService, VpnManager.VpnS
         return data;
     }
 
+    private void logLanProxyAddresses() {
+        if (m_tunnelConfig == null || !m_tunnelConfig.shareProxyOnNetwork) {
+            return;
+        }
+
+        int httpPort = m_tunnelState.listeningLocalHttpProxyPort;
+        int socksPort = m_tunnelState.listeningLocalSocksProxyPort;
+        if (httpPort <= 0 && socksPort <= 0) {
+            return;
+        }
+
+        List<LocalProxyInterfaces.InterfaceAddress> addresses =
+                LocalProxyInterfaces.getAvailableAddresses();
+        if (addresses.isEmpty()) {
+            return;
+        }
+
+        MyLog.i(R.string.log_lan_proxy_addresses,
+                MyLog.Sensitivity.SENSITIVE_FORMAT_ARGS,
+                LocalProxyInterfaces.formatProxyAddresses(getContext(), addresses, httpPort, socksPort));
+    }
+
     private Bundle getDataTransferStatsBundle() {
         Bundle data = new Bundle();
         data.putLong(DATA_TRANSFER_STATS_CONNECTED_TIME, DataTransferStats.getDataTransferStatsForService().m_connectedTime);
@@ -2241,6 +2263,11 @@ public class TunnelManager implements PsiphonTunnel.HostService, VpnManager.VpnS
             public void run() {
                 MyLog.i(R.string.socks_running, MyLog.Sensitivity.NOT_SENSITIVE, port);
                 m_tunnelState.listeningLocalSocksProxyPort = port;
+
+                final AppPreferences multiProcessPreferences = new AppPreferences(getContext());
+                multiProcessPreferences.put(
+                        m_parentService.getString(R.string.current_local_socks_proxy_port),
+                        port);
             }
         });
     }
@@ -2339,6 +2366,7 @@ public class TunnelManager implements PsiphonTunnel.HostService, VpnManager.VpnS
                 DataTransferStats.getDataTransferStatsForService().startConnected();
 
                 MyLog.i(R.string.tunnel_connected, MyLog.Sensitivity.NOT_SENSITIVE);
+                logLanProxyAddresses();
 
                 m_networkConnectionStatePublishRelay.accept(TunnelState.ConnectionData.NetworkConnectionState.CONNECTED);
             }

--- a/app/src/main/res/layout/home_tab_layout.xml
+++ b/app/src/main/res/layout/home_tab_layout.xml
@@ -97,6 +97,18 @@
                         android:textColor="#DDDDDD" />
 
                     <TextView
+                        android:id="@+id/lanProxyInterfacesText"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:gravity="center"
+                        android:textAlignment="center"
+                        android:paddingTop="8dp"
+                        android:textSize="11sp"
+                        android:fontFamily="monospace"
+                        android:textColor="#CCCCCC" />
+
+                    <TextView
                         android:id="@+id/lanProxyHint"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"

--- a/app/src/main/res/values-fa-rAF/strings.xml
+++ b/app/src/main/res/values-fa-rAF/strings.xml
@@ -173,4 +173,16 @@
   <string name="lan_proxy_sharing_active">اشتراک‌گذاری شبکه فعال است</string>
   <string name="lan_proxy_configure_hint">تنظیمات پروکسی دستگاه‌های دیگر را با این آدرس‌ها پیکربندی کنید</string>
   <string name="log_lan_sharing_enabled">اشتراک‌گذاری شبکه فعال شد — پروکسی در شبکه محلی در دسترس است</string>
+  <string name="lan_proxy_interface_name">%1$s (%2$s)</string>
+  <string name="lan_proxy_interface_address">%1$s: %2$s</string>
+  <string name="lan_proxy_interface_hotspot">هات‌اسپات</string>
+  <string name="lan_proxy_interface_wifi">وای‌فای</string>
+  <string name="lan_proxy_interface_usb">اشتراک‌گذاری USB</string>
+  <string name="lan_proxy_interface_ethernet">اترنت</string>
+  <string name="lan_proxy_interface_bluetooth">اشتراک‌گذاری بلوتوث</string>
+  <string name="lan_proxy_interface_local">شبکه محلی</string>
+  <string name="log_lan_proxy_addresses">آدرس‌های پروکسی شبکه:\n%1$s</string>
+  <string name="preference_network_sharing_addresses_title">آدرس‌های پروکسی موجود</string>
+  <string name="preference_network_sharing_addresses_unavailable">در حال حاضر هیچ آداپتور شبکه محلی در دسترس نیست.</string>
+  <string name="preference_network_sharing_addresses_ports_unavailable">برای نمایش پورت‌های HTTP و SOCKS، یک بار با اشتراک‌گذاری شبکه متصل شوید.</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -210,5 +210,17 @@
   <string name="lan_proxy_sharing_active">اشتراک‌گذاری شبکه فعال است</string>
   <string name="lan_proxy_configure_hint">تنظیمات پروکسی دستگاه‌های دیگر را با این آدرس‌ها پیکربندی کنید</string>
   <string name="log_lan_sharing_enabled">اشتراک‌گذاری شبکه فعال شد — پروکسی در شبکه محلی در دسترس است</string>
+  <string name="lan_proxy_interface_name">%1$s (%2$s)</string>
+  <string name="lan_proxy_interface_address">%1$s: %2$s</string>
+  <string name="lan_proxy_interface_hotspot">هات‌اسپات</string>
+  <string name="lan_proxy_interface_wifi">وای‌فای</string>
+  <string name="lan_proxy_interface_usb">اشتراک‌گذاری USB</string>
+  <string name="lan_proxy_interface_ethernet">اترنت</string>
+  <string name="lan_proxy_interface_bluetooth">اشتراک‌گذاری بلوتوث</string>
+  <string name="lan_proxy_interface_local">شبکه محلی</string>
+  <string name="log_lan_proxy_addresses">آدرس‌های پروکسی شبکه:\n%1$s</string>
+  <string name="preference_network_sharing_addresses_title">آدرس‌های پروکسی موجود</string>
+  <string name="preference_network_sharing_addresses_unavailable">در حال حاضر هیچ آداپتور شبکه محلی در دسترس نیست.</string>
+  <string name="preference_network_sharing_addresses_ports_unavailable">برای نمایش پورت‌های HTTP و SOCKS، یک بار با اشتراک‌گذاری شبکه متصل شوید.</string>
 
 </resources>

--- a/app/src/main/res/values/psiphon_android_library_untranslated_strings.xml
+++ b/app/src/main/res/values/psiphon_android_library_untranslated_strings.xml
@@ -43,6 +43,7 @@
     <string name="upgrade_checker_service_name">ShirOKhorshid:UpgradeChecker</string>
 
     <string name="current_local_http_proxy_port">currentLocalHttpProxyPort</string>
+    <string name="current_local_socks_proxy_port">currentLocalSocksProxyPort</string>
     <string name="proxyOptionsPreferenceKey" translatable="false">proxyOptionsPreferenceKey</string>
     <string name="vpnOptionsPreferenceKey" translatable="false">vpnOptionsPreferenceKey</string>
     <string name="feedbackPreferenceKey" translatable="false">feedbackPreferenceKey</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,5 +229,17 @@
     <string name="lan_proxy_sharing_active">Network sharing active</string>
     <string name="lan_proxy_configure_hint">Configure other devices\' proxy settings with these addresses</string>
     <string name="log_lan_sharing_enabled">Network sharing enabled — proxy exposed on LAN</string>
+    <string name="lan_proxy_interface_name">%1$s (%2$s)</string>
+    <string name="lan_proxy_interface_address">%1$s: %2$s</string>
+    <string name="lan_proxy_interface_hotspot">Hotspot</string>
+    <string name="lan_proxy_interface_wifi">Wi-Fi</string>
+    <string name="lan_proxy_interface_usb">USB tethering</string>
+    <string name="lan_proxy_interface_ethernet">Ethernet</string>
+    <string name="lan_proxy_interface_bluetooth">Bluetooth tethering</string>
+    <string name="lan_proxy_interface_local">Local network</string>
+    <string name="log_lan_proxy_addresses">Network proxy addresses:\n%1$s</string>
+    <string name="preference_network_sharing_addresses_title">Available proxy addresses</string>
+    <string name="preference_network_sharing_addresses_unavailable">No local network adapters are currently available.</string>
+    <string name="preference_network_sharing_addresses_ports_unavailable">Connect once with network sharing enabled to show HTTP and SOCKS ports.</string>
 
 </resources>

--- a/app/src/main/res/xml/more_options_preferences.xml
+++ b/app/src/main/res/xml/more_options_preferences.xml
@@ -88,6 +88,11 @@
             android:inputType="textUri|textNoSuggestions"
             android:summary="@string/cdnFrontingCustomSniPreferenceSummary"
             android:title="@string/cdnFrontingCustomSniPreferenceTitle" />
+        <Preference
+            android:icon="@drawable/ic_cdn_edge"
+            android:key="cdnFrontingScanner"
+            android:summary="@string/cdnFrontingScannerPreferenceSummary"
+            android:title="@string/cdnFrontingScannerPreferenceTitle" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="conduitCategory"
@@ -131,6 +136,11 @@
             android:title="@string/preference_share_proxy_title"
             android:summary="@string/preference_share_proxy_summary"
             android:defaultValue="false" />
+        <Preference
+            android:key="networkSharingAddresses"
+            android:title="@string/preference_network_sharing_addresses_title"
+            android:summary="@string/preference_network_sharing_addresses_unavailable"
+            android:selectable="false" />
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/preference_category_stealth_title">


### PR DESCRIPTION
This adds a read-only address summary to the Network Sharing section so users can see which local interface/IP should be used from another device.

Changes included:

- lists available local IPv4 interfaces with a readable label and the real adapter name, for example `Wi‑Fi (wlan0)` or `Hotspot (ap0)`
- shows HTTP and SOCKS proxy endpoints once the tunnel has reported its listening ports
- keeps the existing home-screen proxy address display, but expands it to show all detected local interfaces
- writes the same proxy address details to the log after a successful connection when network sharing is enabled
- filters out VPN/tunnel/mobile interfaces so the list focuses on usable local network addresses

This should make hotspot, Wi‑Fi, USB tethering, and Ethernet sharing less ambiguous for users configuring another device manually.

Validation:

- checked the patch for whitespace issues
- tested locally in the app before opening the PR
